### PR TITLE
Loosen constraint on Rails version

### DIFF
--- a/iban_bic.gemspec
+++ b/iban_bic.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{data,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", "~> 6.1"
+  s.add_dependency "rails", ">= 5.1"
   s.add_dependency "regexp-examples", "~> 1.3"
 
   s.add_development_dependency "codecov", "~> 0.1"


### PR DESCRIPTION
Hello there.

This is a proposition to make the gem work with Rails 7 with minimal effort.

As far as I know, the gem works with Rails 7. The tests on my Rails 7 app are passing.

I tried to update the `test_app` in the gem, but ran into issues with sprockets, and I don't have enough time to fix them.

I believe that changing `rails` dependency from `~> 6.1` to `>= 5.1` would create less frustration amongst users, while still letting people report bugs if any is encountered. It seems to be a better option that just making the gem impossible to use with Rails 7.

Thank you for you time!