### PR TITLE
 fix: moldova regexp has no branch but an account

### DIFF
--- a/data/iban_meta.yml
+++ b/data/iban_meta.yml
@@ -119,7 +119,7 @@ MC:
   parts: (?<iban_check>\d{2}) (?<bank>\d{5})         (?<branch>\d{5})         (?<account>[A-Z0-9]{11}) (?<check>\d{2})
   tags: sepa
 MD:
-  parts: (?<iban_check>\d{2}) (?<bank>\d{2})         (?<account>[A-Z0-9]{18})
+  parts: (?<iban_check>\d{2}) (?<bank>[A-Z0-9]{2})   (?<account>[A-Z0-9]{18})
   tags:
 ME:
   parts: (?<iban_check>\d{2}) (?<bank>\d{3})         (?<account>\d{12})       (?<check>\d{2})

--- a/spec/iban_bic/core_spec.rb
+++ b/spec/iban_bic/core_spec.rb
@@ -146,7 +146,15 @@ RSpec.describe(::IbanBic) do
   describe "#parse" do
     subject(:method) { IbanBic.parse(iban) }
 
-    it { is_expected.to include(country: "ES", bank: "0003", branch: "0000", check: country_digits, account: "0000000000") }
+    context "when iban country is Spain" do
+      it { is_expected.to include(country: "ES", bank: "0003", branch: "0000", check: country_digits, account: "0000000000") }
+    end
+
+    context "when iban country is Moldova" do
+      let(:iban) { "MD24AG000225100013104168" }
+
+      it { is_expected.to include(country: "MD", iban_check: "24", bank: "AG", account: "000225100013104168") }
+    end
   end
 
   describe "#valid?" do


### PR DESCRIPTION
This PR fixes the IBAN regexp for Moldova which expects an alphanumeric bank code.

Below is the typical IBAN for Moldova. It contains 24 characters. Below you will find a detailed breakdown of the IBAN structure in Moldova.

- 2 letters ISO country code
- 2 digits IBAN check digits
- **2 characters bank code**
- 18 characters account number

```
MD 24 AG 000225100013104168 
```

source: https://bank.codes/iban/structure/moldova/